### PR TITLE
Set max inactive interval to 30 days

### DIFF
--- a/src/main/java/com/jolocom/webidproxy/LoginServlet.java
+++ b/src/main/java/com/jolocom/webidproxy/LoginServlet.java
@@ -30,6 +30,7 @@ public class LoginServlet extends BaseServlet {
 		}
 
 		HttpSession session = request.getSession(true);
+		session.setMaxInactiveInterval(2592000);
 		session.setAttribute("username", username);
 		session.setAttribute("HTTPCLIENT", null);
 


### PR DESCRIPTION
The current interval is too short and is not user friendly.

I'm not sure if it works like this, can you confirm @peacekeeper?