### PR TITLE
Returning the user's email on account activation.

### DIFF
--- a/src/main/java/com/jolocom/webidproxy/VerifyEmailServlet.java
+++ b/src/main/java/com/jolocom/webidproxy/VerifyEmailServlet.java
@@ -25,12 +25,11 @@ public class VerifyEmailServlet extends BaseServlet {
 			this.error(request, response, HttpServletResponse.SC_BAD_REQUEST, "User " + username + " cannot verify e-mail.");
 			return;
 		}
-
+		
 		user.setVerificationcode(null);
 		WebIDProxyServlet.users.put(user);
 
-		String content = "{}";
-
+		String content = "{\"email\":\"" + user.getEmail() + "\"}";
 		this.success(request, response, content, "application/json");
 	}
 }

--- a/src/main/java/com/jolocom/webidproxy/VerifyEmailServlet.java
+++ b/src/main/java/com/jolocom/webidproxy/VerifyEmailServlet.java
@@ -29,7 +29,7 @@ public class VerifyEmailServlet extends BaseServlet {
 		user.setVerificationcode(null);
 		WebIDProxyServlet.users.put(user);
 
-		String content = "{\"email\":\"" + user.getEmail() + "\", \"webId\":\"" + user.getWebid() + "\"}";
+		String content = "{\"email\":\"" + user.getEmail() + "\"}";
 		this.success(request, response, content, "application/json");
 	}
 }

--- a/src/main/java/com/jolocom/webidproxy/VerifyEmailServlet.java
+++ b/src/main/java/com/jolocom/webidproxy/VerifyEmailServlet.java
@@ -29,7 +29,7 @@ public class VerifyEmailServlet extends BaseServlet {
 		user.setVerificationcode(null);
 		WebIDProxyServlet.users.put(user);
 
-		String content = "{\"email\":\"" + user.getEmail() + "\"}";
+		String content = "{\"email\":\"" + user.getEmail() + "\", \"webId\":\"" + user.getWebid() + "\"}";
 		this.success(request, response, content, "application/json");
 	}
 }

--- a/src/main/java/com/jolocom/webidproxy/VerifyEmailServlet.java
+++ b/src/main/java/com/jolocom/webidproxy/VerifyEmailServlet.java
@@ -25,11 +25,12 @@ public class VerifyEmailServlet extends BaseServlet {
 			this.error(request, response, HttpServletResponse.SC_BAD_REQUEST, "User " + username + " cannot verify e-mail.");
 			return;
 		}
-		
+
 		user.setVerificationcode(null);
 		WebIDProxyServlet.users.put(user);
 
 		String content = "{\"email\":\"" + user.getEmail() + "\"}";
+
 		this.success(request, response, content, "application/json");
 	}
 }

--- a/src/main/java/com/jolocom/webidproxy/users/User.java
+++ b/src/main/java/com/jolocom/webidproxy/users/User.java
@@ -24,8 +24,9 @@ public class User {
 	public String certificate;
 	public String recoverycode;
 	public String verificationcode;
+	public String email;
 
-	User(String username, String password, String name, String webid, String spkac, String privatekey, String certificate, String recoverycode, String verificationcode) {
+	User(String username, String password, String name, String webid, String spkac, String privatekey, String certificate, String recoverycode, String verificationcode, String email) {
 
 		this.username = username;
 		this.password = password;
@@ -36,6 +37,7 @@ public class User {
 		this.certificate = certificate;
 		this.recoverycode = recoverycode;
 		this.verificationcode = verificationcode;
+		this.email = email;
 	}
 
 	User(String username, String password, String name, String email) {
@@ -43,6 +45,7 @@ public class User {
 		this.username = username;
 		this.password = password;
 		this.name = name;
+		this.email = email;
 
 		if (Config.vhosts()) {
 
@@ -70,7 +73,6 @@ public class User {
 	}
 
 	static User fromProperties(Properties properties) {
-
 		return new User(
 				properties.getProperty("username"),
 				properties.getProperty("password"),
@@ -80,7 +82,8 @@ public class User {
 				properties.getProperty("privatekey"),
 				properties.getProperty("certificate"),
 				properties.getProperty("recoverycode"),
-				properties.getProperty("verificationcode"));
+				properties.getProperty("verificationcode"),
+				properties.getProperty("email"));
 	}
 
 	static Properties toProperties(User user) {
@@ -95,6 +98,7 @@ public class User {
 		if (user.getCertificate() != null) properties.setProperty("certificate", user.getCertificate());
 		if (user.getRecoverycode() != null) properties.setProperty("recoverycode", user.getRecoverycode());
 		if (user.getVerificationcode() != null) properties.setProperty("verificationcode", user.getVerificationcode());
+		if (user.getEmail() != null) properties.setProperty("email", user.getEmail());
 
 		return properties;
 	}
@@ -171,6 +175,13 @@ public class User {
 		this.verificationcode = verificationcode;
 	}
 
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
 	@Override
 	public String toString() {
 		return "User [username=" + username + ", name=" + name + ", webid=" + webid + "]";

--- a/src/main/java/com/jolocom/webidproxy/users/User.java
+++ b/src/main/java/com/jolocom/webidproxy/users/User.java
@@ -73,6 +73,7 @@ public class User {
 	}
 
 	static User fromProperties(Properties properties) {
+
 		return new User(
 				properties.getProperty("username"),
 				properties.getProperty("password"),
@@ -182,6 +183,7 @@ public class User {
 	public void setEmail(String email) {
 		this.email = email;
 	}
+
 	@Override
 	public String toString() {
 		return "User [username=" + username + ", name=" + name + ", webid=" + webid + "]";

--- a/src/main/java/com/jolocom/webidproxy/users/UsersFileImpl.java
+++ b/src/main/java/com/jolocom/webidproxy/users/UsersFileImpl.java
@@ -119,6 +119,7 @@ public class UsersFileImpl implements Users {
 		reader.close();
 
 		// done
+
 		User user = User.fromProperties(properties);
 		log.debug("Loaded user " + user);
 		return user;

--- a/src/main/java/com/jolocom/webidproxy/users/UsersFileImpl.java
+++ b/src/main/java/com/jolocom/webidproxy/users/UsersFileImpl.java
@@ -119,7 +119,6 @@ public class UsersFileImpl implements Users {
 		reader.close();
 
 		// done
-
 		User user = User.fromProperties(properties);
 		log.debug("Loaded user " + user);
 		return user;

--- a/src/main/resources/email-register.vm
+++ b/src/main/resources/email-register.vm
@@ -4,4 +4,4 @@ WebID Registration
 Thank you for registering your WebID! ${newline}
 Please verify your e-mail address by clicking on this link:${newline}
 ${newline}
-https://littlesister.jolocom.com/#/verify-email/${user.username}/${user.verificationcode} ${newline}
+https://testing.littlesister.jolocom.com/#/verify-email/${user.username}/${user.verificationcode} ${newline}


### PR DESCRIPTION
We would like the proxy server to include the user's email address in the response to the email verification request. Discussed in more detail here [here](https://github.com/jolocom/little-sister/pull/457)